### PR TITLE
[fix] expose Kafka port for external traffic

### DIFF
--- a/vagrantfiles/Vagrantfile.centos.1
+++ b/vagrantfiles/Vagrantfile.centos.1
@@ -43,7 +43,7 @@ Vagrant.configure("2") do |config|
     # zookeeper
     config.vm.network(:forwarded_port, {:guest=>2181, :host=>2181})    
     # kafka
-    config.vm.network(:forwarded_port, {:guest=>9091, :host=>9091})    
+    config.vm.network(:forwarded_port, {:guest=>9092, :host=>9092})    
     # sqoop
     config.vm.network(:forwarded_port, {:guest=>16000, :host=>16000})    
 

--- a/vagrantfiles/Vagrantfile.ubuntu.1
+++ b/vagrantfiles/Vagrantfile.ubuntu.1
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
     # zookeeper
     config.vm.network(:forwarded_port, {:guest=>2181, :host=>2181})    
     # kafka
-    config.vm.network(:forwarded_port, {:guest=>9091, :host=>9091})    
+    config.vm.network(:forwarded_port, {:guest=>9092, :host=>9092})    
     # sqoop
     config.vm.network(:forwarded_port, {:guest=>16000, :host=>16000})    
 


### PR DESCRIPTION
Kafka is configured to use port 9091 for internal traffic. For external it's 9092