### PR TITLE
perl port substition fix

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -57,8 +57,7 @@ function replace_port() {
 #      	 http_port=$p
 #         echo "http_port -> $p"
       else
-        perl -pi -e "s/$forwarded_port/$p/g" Vagrantfile
-        perl -pi -e "s/$p/$forwarded_port/" Vagrantfile
+        perl -pi -e "s/host=>$forwarded_port/host=>$p/g" Vagrantfile
         echo "$port -> $p"
       fi
     else


### PR DESCRIPTION
the current substitution rule will fail on the following:
hopsworks0.vm.network(:forwarded_port, {:guest=>8080, :host=>8080})
hopsworks0.vm.network(:forwarded_port, {:guest=>18080, :host=>18080})
as it will substitute in both line the 8080 ports and it will also fail as the second port will be too big for a port number, since most likely the generated random port will already be of 5 digits.