### PR TITLE
Temporarily increase memory of master node for 3 VMs setups

### DIFF
--- a/vagrantfiles/Vagrantfile.centos.3
+++ b/vagrantfiles/Vagrantfile.centos.3
@@ -114,7 +114,7 @@ Vagrant.configure("2") do |config|
 
     hopsworks0.vm.provider :virtualbox do |v|
       v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-      v.customize ["modifyvm", :id, "--memory", 15048]
+      v.customize ["modifyvm", :id, "--memory", 32768]
       v.customize ["modifyvm", :id, "--name", "hopsworks0"]
       v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       v.customize ["modifyvm", :id, "--cpus", "4"]

--- a/vagrantfiles/Vagrantfile.ubuntu.3
+++ b/vagrantfiles/Vagrantfile.ubuntu.3
@@ -123,7 +123,7 @@ Vagrant.configure("2") do |config|
 
     hopsworks0.vm.provider :virtualbox do |v|
       v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
-      v.customize ["modifyvm", :id, "--memory", 15048]
+      v.customize ["modifyvm", :id, "--memory", 32768]
       v.customize ["modifyvm", :id, "--name", "hopsworks0"]
       v.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       v.customize ["modifyvm", :id, "--nictype1", "virtio"]


### PR DESCRIPTION
After adding `consul` recipes, Karamel is throwing OutOfMemory error when trying to convert a yaml to json.

Temporarily increase the memory of the master node to increase the maximum Java heap size