### PR TITLE
[HOPSWORKS-1724 ]fixes counting available Nvidia GPUs

### DIFF
--- a/hopsworks-installer.sh
+++ b/hopsworks-installer.sh
@@ -560,7 +560,7 @@ add_worker()
 	fi
     fi       
     
-    WORKER_GPUS=$(ssh -t -o StrictHostKeyChecking=no $WORKER_IP "sudo lspci | grep -i nvidia | wc -l")
+    WORKER_GPUS=$(ssh -t -o StrictHostKeyChecking=no $WORKER_IP "sudo lspci | grep -i 'vga.*nvidia' | wc -l")
     # strip carriage return '\r' from variable to make it a number
     WORKER_GPUS=$(echo $WORKER_GPUS|tr -d '\r')
     
@@ -860,7 +860,7 @@ if [ $? -ne 0 ] ; then
    echo "Installing pciutils ...."
    sudo yum install pciutils -y > /dev/null
 fi    
-AVAILABLE_GPUS=$(sudo lspci | grep -i nvidia | wc -l)
+AVAILABLE_GPUS=$(sudo lspci | grep -i 'vga.*nvidia' | wc -l)
 
 
 if [ $NON_INTERACT -eq 0 ] ; then


### PR DESCRIPTION
Excludes other Nvidia devices (e.g., Audio, USB controllers) from the GPU count.