### PR TITLE
[HOPSWORKS-3030] support to start glassfish in debug mode and add new capabilities to run.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cluster.yml
 env.sh
 # this file is used to store the path to Enterprise Hopsworks
 cloud-tests/util/env.sh
+.deploy.sh

--- a/cloud/deploy-ear.sh
+++ b/cloud/deploy-ear.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+USER=jdowling
+VERSION="2.6.0-SNAPSHOT"
+
+cd /tmp
+
+rm -f hopsworks-*
+scp ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-ear/target/*.ear .
+
+if [ "$1" == "war" ] ; then 
+  rm -f hopsworks*.war
+  scp ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-web/target/*.war .
+fi
+
+sudo su glassfish <<EOF
+
+#/srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false create-protocol --securityenabled=true http-1
+
+
+#/srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false 
+
+/srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false undeploy --target server hopsworks-ear:$VERSION
+
+echo "Installing new hopsworks-ear.ear"
+/srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false --echo=true --terse=false deploy --name hopsworks-ear:$VERSION --force=true --precompilejsp=true --verify=false --enabled=true --generatermistubs=false --availabilityenabled=false --asyncreplication=false --target server --keepreposdir=false --keepfailedstubs=false --isredeploy=false --logreportederrors=true --keepstate=false --lbenabled true --_classicstyle=false --upload=true hopsworks-ear.ear
+
+
+if [ "$1" == "war" ] ; then 
+
+  /srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false undeploy --target server hopsworks-web:$VERSION
+
+  /srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false --echo=true --terse=false deploy --name hopsworks-web:$VERSION --force=true --precompilejsp=true --verify=false --enabled=true --generatermistubs=false --availabilityenabled=false --asyncreplication=false --target server --keepreposdir=false --keepfailedstubs=false --isredeploy=false --logreportederrors=true --keepstate=false --lbenabled true --_classicstyle=false --upload=true hopsworks-web.war
+
+fi
+
+EOF
+

--- a/cluster-defns/1.hopsworks.yml
+++ b/cluster-defns/1.hopsworks.yml
@@ -21,6 +21,7 @@ attrs:
   prometheus:
     retention_time: "2h"
   hopsworks:
+    debug: true
     featurestore_online: true
     kagent_liveness:
       enabled: true

--- a/run.sh
+++ b/run.sh
@@ -128,6 +128,8 @@ function deploy_ear() {
       cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
     fi
 
+    echo ""
+    echo ""
     echo "You can redeploy your ear on Vagrant after you follow these instructions: "
     echo "On dev4.hops.works:"
     echo ""
@@ -159,7 +161,6 @@ function ssh_config() {
     echo "Host dev4"
     echo "  Hostname dev4.hops.works"
     echo "  User $USER"
-    echo ""
     echo "Host vagrant"
     echo "  Hostname dev4.hops.works"
     echo "  User $USER"
@@ -342,7 +343,4 @@ parse_ports
 deploy_ear
 ssh_config
 
-echo ""
-echo "Connect your browser to: http://$(hostname):${http_port}/hopsworks"
-echo ""
 exit 0

--- a/run.sh
+++ b/run.sh
@@ -3,14 +3,12 @@
 function help() {
   echo "Usage: ./run.sh [centos|ubuntu|ports|ssh-config|deploy-ear] [1|3] [ndb|hopsworks|hops|jim|antonios||etc] [no-random-ports] [udp-hack]"
   echo ""
-  echo "Create your own cluster definition from an existing one:"
-  echo "cp cluster.1.hopsworks cluster.1.jim"
-  echo "For example, for a 1-node hopsworks cluster on ubuntu for development with random ports, run:"
+  echo "Create a custom cluster definition from an existing one:"
+  echo "cp cluster-defns/1.hopsworks.yml cluster-defns/1.jim.yml"
+  echo ""
+  echo "For a hopsworks cluster on ubuntu or centos, run:"
   echo "./run.sh ubuntu 1 jim"
-  echo "For centos without random ports, run:"
-  echo "./run.sh centos 1 centos no-random-ports"
-  echo "To find out the currently mapped ports, run:"
-  echo "./run.sh ports"
+  echo "./run.sh centos 1 centos"
   exit 1
 }
 

--- a/run.sh
+++ b/run.sh
@@ -103,7 +103,6 @@ function parse_ports() {
     IFS=$'\n'
     ports=$(grep forward Vagrantfile | grep -Eo '[0-9]{2,5}'|xargs)
     count=0
-    echo "Found forwarded Ports:"
     ports=($ports)
     # Restore IFS
     IFS=$SAVEIFS
@@ -167,6 +166,7 @@ function ssh_config() {
     DEBUG_PORT=0
     HTTPS_PORT=0
     GLASSFISH_PORT=0
+    KARAMEL_PORT=0
 
     
     SAVEIFS=$IFS
@@ -191,6 +191,9 @@ function ssh_config() {
 	    if [ $GLASSFISH_PORT -eq 4848 ] ; then
 	      GLASSFISH_PORT=$i	
 	    fi
+	    if [ $KARAMEL_PORT -eq 9090 ] ; then
+	      KARAMEL_PORT=$i	
+	    fi
 	else
 	    if [ $i -eq 9009 ] ; then
 		DEBUG_PORT=9009
@@ -201,6 +204,9 @@ function ssh_config() {
 	    if [ $i -eq 4848 ] ; then
 		GLASSFISH_PORT=4848
 	    fi
+	    if [ $i -eq 9090 ] ; then
+		KARAMEL_PORT=9090
+	    fi
 	fi
 	count=$(($count + 1))
     done
@@ -208,6 +214,7 @@ function ssh_config() {
     echo "  LocalForward 9009 localhost:$DEBUG_PORT"
     echo "  LocalForward 8181 localhost:$HTTPS_PORT"
     echo "  LocalForward 4848 localhost:$GLASSFISH_PORT"
+    echo "  LocalForward 9090 localhost:$KARAMEL_PORT"
     
 }
 

--- a/run.sh
+++ b/run.sh
@@ -174,7 +174,6 @@ function ssh_config() {
     IFS=$'\n'
     ports=$(grep forward Vagrantfile | grep -Eo '[0-9]{2,5}'|xargs)
     count=0
-    echo "Found forwarded Ports:"
     ports=($ports)
     # Restore IFS
     IFS=$SAVEIFS

--- a/run.sh
+++ b/run.sh
@@ -122,7 +122,16 @@ function deploy_ear() {
     ssh_key=$(cat ${HOME}/.ssh/id_rsa.pub)
     grep $ssh_key ~/.ssh/authorized_keys >/dev/null 2>&1
     if [ $? -ne 0 ] ; then
-      cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+      if [ -f ~/.ssh/id_rsa.pub ] ; then
+        cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+      else
+	echo "----------------------------------------------------------"
+	echo "WARNING: the deploy-ear.sh script will not work as you do not have a"
+	echo "public-private key"
+	echo "To fix this problem, create a public/private ssh key with no password with this command:"
+	echo "cat /dev/zero | ssh-keygen -m PEM -q -N > /dev/null "
+	echo "----------------------------------------------------------"
+      fi
     fi
 
     echo ""

--- a/run.sh
+++ b/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function help() {
-  echo "Usage: ./run.sh [centos|ubuntu|ports|ssh-config] [1|3] [ndb|hopsworks|hops|jim|antonios|theofilos|demodela|etc] [no-random-ports] [udp-hack]"
+  echo "Usage: ./run.sh [centos|ubuntu|ports|ssh-config|deploy-ear] [1|3] [ndb|hopsworks|hops|jim|antonios||etc] [no-random-ports] [udp-hack]"
   echo ""
   echo "Create your own cluster definition from an existing one:"
   echo "cp cluster.1.hopsworks cluster.1.jim"
@@ -17,7 +17,7 @@ function help() {
 port=
 forwarded_port=
 ports=
-#http_port=8080
+
 
 VBOX_MANAGE=/usr/bin/VBoxManage
 OCTETS="192.168."
@@ -119,6 +119,40 @@ function parse_ports() {
 	count=$(($count + 1))
     done
 }
+
+function deploy_ear() {
+    
+    ssh_key=$(cat ${HOME}/.ssh/id_rsa.pub)
+    grep $ssh_key ~/.ssh/authorized_keys >/dev/null 2>&1
+    if [ $? -ne 0 ] ; then
+      cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+    fi
+
+#    echo "1. change unit file to start in debug mode"
+#    vagrant ssh "sudo sed -i \"s/-debug false/-debug true/\" /lib/systemd/system/glassfish-domain1.service"
+#    echo "2. reload systemd unit files"
+#    vagrant ssh "sudo systemctl daemon-reload"
+#    echo "3. restart glassfish"
+#    echo "Restarting glassfish in debug mode. This will take 5 mins...."
+#    vagrant ssh "sudo systemctl restart glassfish-domain1"
+
+    echo "You can redeploy your ear on Vagrant after you follow these instructions: "
+    echo "On dev4.hops.works:"
+    echo ""
+    echo "mkdir Projects"
+    echo "cd Projects"
+    echo "# Change this from jimdowling to your private github repo"
+    echo "git clone git@github.com:jimdowling/hopsworks-ee.git"
+    echo "cd Projects/hopsworks-ee"
+    echo "mvn clean install -Pkube,web,jupyter-git -DskipTests"
+    echo ""
+    echo "cd ~/karamel-chef"
+    echo "vagrant ssh"
+    echo "#now on vagrant, copies the hopsworks-ear.ear file from dev4, and deploys it to glassfish"
+    echo "./deploy-ear.sh"
+    echo ""
+}
+
 
 function ssh_config() {
     echo "=========================================="
@@ -222,6 +256,11 @@ if [ "$1" == "ssh-config" ] ; then
  exit 0
 fi
 
+if [ "$1" == "deploy-ear" ] ; then
+ deploy_ear
+ exit 0
+fi
+
 
 if [ $# -lt 3 ] ; then
     help
@@ -266,7 +305,7 @@ fi
 cp vagrantfiles/Vagrantfile.$1.$2 Vagrantfile
 cp cluster-defns/$2.$3.yml cluster.yml
 
-cp -f cloud/deploy-ear.sh .deploy.sh
+cp -f scripts/deploy-ear.sh .deploy.sh
 sed -i "s/__USER__/$USER/g" .deploy.sh
 
 if [ $PORTS -eq 1 ] ; then

--- a/run.sh
+++ b/run.sh
@@ -138,6 +138,7 @@ function deploy_ear() {
     echo "# Change this from jimdowling to your private github repo"
     echo "git clone git@github.com:jimdowling/hopsworks-ee.git"
     echo "cd Projects/hopsworks-ee"
+    echo "./scripts/allow-cors.sh"
     echo "mvn clean install -Pkube,web,jupyter-git -DskipTests"
     echo ""
     echo "cd ~/karamel-chef"

--- a/run.sh
+++ b/run.sh
@@ -128,14 +128,6 @@ function deploy_ear() {
       cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
     fi
 
-#    echo "1. change unit file to start in debug mode"
-#    vagrant ssh "sudo sed -i \"s/-debug false/-debug true/\" /lib/systemd/system/glassfish-domain1.service"
-#    echo "2. reload systemd unit files"
-#    vagrant ssh "sudo systemctl daemon-reload"
-#    echo "3. restart glassfish"
-#    echo "Restarting glassfish in debug mode. This will take 5 mins...."
-#    vagrant ssh "sudo systemctl restart glassfish-domain1"
-
     echo "You can redeploy your ear on Vagrant after you follow these instructions: "
     echo "On dev4.hops.works:"
     echo ""
@@ -347,6 +339,8 @@ if [ $UDP_HACK -eq 1 ]; then
 fi
 
 parse_ports
+deploy_ear
+ssh_config
 
 echo ""
 echo "Connect your browser to: http://$(hostname):${http_port}/hopsworks"

--- a/scripts/deploy-ear.sh
+++ b/scripts/deploy-ear.sh
@@ -6,11 +6,11 @@ VERSION="2.6.0-SNAPSHOT"
 cd /tmp
 
 rm -f hopsworks-*
-scp ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-ear/target/*.ear .
+scp -i ~/.ssh/id_rsa_dev ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-ear/target/*.ear .
 
 if [ "$1" == "war" ] ; then 
   rm -f hopsworks*.war
-  scp ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-web/target/*.war .
+  scp -i ~/.ssh/id_rsa_dev ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-web/target/*.war .
 fi
 
 sudo su glassfish <<EOF

--- a/scripts/deploy-ear.sh
+++ b/scripts/deploy-ear.sh
@@ -1,24 +1,23 @@
 #!/bin/bash
 
-USER=jdowling
-VERSION="2.6.0-SNAPSHOT"
+export USER=__USER__
+export VERSION="2.6.0-SNAPSHOT"
+export SERVER="dev4.hops.works"
+export HOPSWORKS_DIR="/home/$USER/Projects/hopsworks-ee"
+export WAR=$1 # set to 'war' to also deploy the war file
 
 cd /tmp
 
 rm -f hopsworks-*
-scp -i ~/.ssh/id_rsa_dev ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-ear/target/*.ear .
+scp -i ~/.ssh/id_rsa_dev ${USER}@${SERVER}:${HOPSWORKS_DIR}/hopsworks-ear/target/*.ear .
 
-if [ "$1" == "war" ] ; then 
+if [ "$WAR" == "war" ] ; then 
   rm -f hopsworks*.war
-  scp -i ~/.ssh/id_rsa_dev ${USER}@dev4.hops.works:~/Projects/hopsworks-ee/hopsworks-web/target/*.war .
+  scp -i ~/.ssh/id_rsa_dev ${USER}@${SERVER}:${HOPSWORKS_DIR}/hopsworks-web/target/*.war .
 fi
 
 sudo su glassfish <<EOF
 
-#/srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false create-protocol --securityenabled=true http-1
-
-
-#/srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false 
 
 /srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false undeploy --target server hopsworks-ear:$VERSION
 
@@ -26,7 +25,7 @@ echo "Installing new hopsworks-ear.ear"
 /srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false --echo=true --terse=false deploy --name hopsworks-ear:$VERSION --force=true --precompilejsp=true --verify=false --enabled=true --generatermistubs=false --availabilityenabled=false --asyncreplication=false --target server --keepreposdir=false --keepfailedstubs=false --isredeploy=false --logreportederrors=true --keepstate=false --lbenabled true --_classicstyle=false --upload=true hopsworks-ear.ear
 
 
-if [ "$1" == "war" ] ; then 
+if [ "$WAR" == "war" ] ; then 
 
   /srv/hops/glassfish/versions/current/bin/asadmin --host localhost --port 4848 --user adminuser --passwordfile /srv/hops/domains/domain1_admin_passwd --interactive=false undeploy --target server hopsworks-web:$VERSION
 

--- a/scripts/restart-glassfish-debug-mode.sh
+++ b/scripts/restart-glassfish-debug-mode.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sudo sed -i \"s/-debug false/-debug true/\" /lib/systemd/system/glassfish-domain1.service
+sudo systemctl daemon-reload
+echo "Restarting glassfish in debug mode. This will take 5 mins...."
+sudo systemctl restart glassfish-domain1
+

--- a/vagrantfiles/Vagrantfile.centos.1
+++ b/vagrantfiles/Vagrantfile.centos.1
@@ -57,6 +57,8 @@ Vagrant.configure("2") do |config|
     config.vm.network(:forwarded_port, {:guest=>8000, :host=>8000})
 
 
+    config.vm.provision "file", source: "~/.ssh/id_rsa", destination: ".ssh/id_rsa_dev"
+    config.vm.provision "file", source: ".deploy.sh", destination: "deploy-ear.sh"
     config.vm.provision "file", source: "cluster.yml", destination: "cluster.yml"
     config.vm.provision "file", source: "~/.vagrant.d/insecure_private_key", destination: "~/.ssh/id_rsa"
     config.vm.provision "shell", inline: "cp /home/vagrant/.ssh/authorized_keys /home/vagrant/.ssh/id_rsa.pub && sudo chown vagrant:vagrant /home/vagrant/.ssh/id_rsa.pub"

--- a/vagrantfiles/Vagrantfile.ubuntu.1
+++ b/vagrantfiles/Vagrantfile.ubuntu.1
@@ -55,6 +55,8 @@ Vagrant.configure("2") do |config|
     # cvat
     config.vm.network(:forwarded_port, {:guest=>8000, :host=>8000})
 
+    config.vm.provision "file", source: "~/.ssh/id_rsa", destination: ".ssh/id_rsa_dev"
+    config.vm.provision "file", source: ".deploy.sh", destination: "deploy-ear.sh"
     config.vm.provision "file", source: "cluster.yml", destination: "cluster.yml"
     config.vm.provision "file", source: "~/.vagrant.d/insecure_private_key", destination: "~/.ssh/id_rsa"
     config.vm.provision "shell", inline: "cp /home/vagrant/.ssh/authorized_keys /home/vagrant/.ssh/id_rsa.pub && sudo chown vagrant:vagrant /home/vagrant/.ssh/id_rsa.pub"

--- a/vagrantfiles/Vagrantfile.ubuntu.3
+++ b/vagrantfiles/Vagrantfile.ubuntu.3
@@ -112,6 +112,8 @@ Vagrant.configure("2") do |config|
     hopsworks0.vm.network(:forwarded_port, {:guest=>11000, :host=>11000})
 
 
+    config.vm.provision "file", source: "~/.ssh/id_rsa", destination: ".ssh/dev_id_rsa"
+    config.vm.provision "file", source: ".deploy.sh", destination: "deploy-ear.sh"
     hopsworks0.vm.provision "file", source: "cluster.yml", destination: "cluster.yml"
     hopsworks0.vm.provision "file", source: "~/.vagrant.d/insecure_private_key", destination: "~/.ssh/id_rsa"
     hopsworks0.vm.provision "shell", inline: "cp /home/vagrant/.ssh/authorized_keys /home/vagrant/.ssh/id_rsa.pub && sudo chown vagrant:vagrant /home/vagrant/.ssh/id_rsa.pub"


### PR DESCRIPTION
Generates a ssh_config file
Adds a scripts to the VM:
~/deploy-ear.sh  
scp's from the host VM in directory ~/Projects/hopsworks-ee/.../hopsworks-ear.ear to the Vagrant VM, then redeploys the .ear file in glassfish.

