### PR TITLE
Fix number of available GPUs in the installer script

### DIFF
--- a/hopsworks-installer.sh
+++ b/hopsworks-installer.sh
@@ -822,7 +822,7 @@ add_worker()
 	fi
     fi
 
-    WORKER_GPUS=$(ssh -t -o StrictHostKeyChecking=no $WORKER_IP "sudo lspci | grep -i nvidia | wc -l")
+    WORKER_GPUS=$(ssh -t -o StrictHostKeyChecking=no $WORKER_IP "sudo lspci | grep -i 'vga.*nvidia' | wc -l")
     # strip carriage return '\r' from variable to make it a number
     WORKER_GPUS=$(echo $WORKER_GPUS|tr -d '\r')
 
@@ -1200,7 +1200,7 @@ if [ $? -ne 0 ] ; then
     echo "Installing pciutils ...."
     sudo yum install pciutils -y > /dev/null
 fi
-AVAILABLE_GPUS=$(sudo lspci | grep -i nvidia | wc -l)
+AVAILABLE_GPUS=$(sudo lspci | grep -i 'vga.*nvidia' | wc -l)
 
 
 if [ $NON_INTERACT -eq 0 ] ; then


### PR DESCRIPTION
The command `sudo lspci | grep -i nvidia` that is used to initialize the number of available GPUs might return inaccurate information, e.g., in my machine with 4 nvidia GPUs it outputs:
```09:00.0 VGA compatible controller: NVIDIA Corporation Device 1e84 (rev a1)
09:00.1 Audio device: NVIDIA Corporation Device 10f8 (rev a1)
09:00.2 USB controller: NVIDIA Corporation Device 1ad8 (rev a1)
09:00.3 Serial bus controller [0c80]: NVIDIA Corporation Device 1ad9 (rev a1)
0a:00.0 VGA compatible controller: NVIDIA Corporation Device 1e84 (rev a1)
0a:00.1 Audio device: NVIDIA Corporation Device 10f8 (rev a1)
0a:00.2 USB controller: NVIDIA Corporation Device 1ad8 (rev a1)
0a:00.3 Serial bus controller [0c80]: NVIDIA Corporation Device 1ad9 (rev a1)
42:00.0 VGA compatible controller: NVIDIA Corporation Device 1e84 (rev a1)
42:00.1 Audio device: NVIDIA Corporation Device 10f8 (rev a1)
42:00.2 USB controller: NVIDIA Corporation Device 1ad8 (rev a1)
42:00.3 Serial bus controller [0c80]: NVIDIA Corporation Device 1ad9 (rev a1)
43:00.0 VGA compatible controller: NVIDIA Corporation Device 1e84 (rev a1)
43:00.1 Audio device: NVIDIA Corporation Device 10f8 (rev a1)
43:00.2 USB controller: NVIDIA Corporation Device 1ad8 (rev a1)
43:00.3 Serial bus controller [0c80]: NVIDIA Corporation Device 1ad9 (rev a1)
```
Hence, the installer will assume that the machine has 16 GPUs.
A workaround is to modify the existing command to only consider the lines with "VGA".

A better fix is to use `nvidia-smi -L | wc -l` instead, but the nvidia driver and `nvidia-smi` might not be installed on the machine when we initialize those variables.