### PR TITLE
[HWORKS-585] Change the download url for maven

### DIFF
--- a/recipes/build.rb
+++ b/recipes/build.rb
@@ -78,7 +78,7 @@ when "debian"
 
 when 'rhel'
   remote_file '/tmp/apache-maven-3.6.3-bin.tar.gz' do
-    source 'https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz'
+    source 'https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.tar.gz'
     owner 'root'
     group 'root'
     mode '0755'


### PR DESCRIPTION
Maven 3.6.3 [Index of /maven/maven-3](https://downloads.apache.org/maven/maven-3/) is not hosted here anymore.